### PR TITLE
Use correct EtherType for 802.1CB in Felix Switch

### DIFF
--- a/drivers/net/dsa/ocelot/felix_tsn.c
+++ b/drivers/net/dsa/ocelot/felix_tsn.c
@@ -19,7 +19,7 @@
 #include "felix_tsn.h"
 #include "felix.h"
 
-#define ETH_P_8021CB		0x2345
+#define ETH_P_8021CB		0xF1C1
 #define FELIX_QSYS_HSCH_NUM	72
 /* MSCC TSN parameters limited */
 #define FELIX_PSFP_SFID_NUM	176


### PR DESCRIPTION
This is documented in the official IEEE 802.1CB specification.  
https://1.ieee802.org/tsn/802-1cb/